### PR TITLE
fix: compatibility with current Home Assistant releases (options flow, coordinator)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-13
+
+### Fixed
+- Options flow crashed on Home Assistant 2025.12+: removed the deprecated explicit
+  `self.config_entry` assignment in `AxeOSOptionsFlowHandler` (support removed by HA core in 2025.12)
+- `DataUpdateCoordinator` is now created with an explicit `config_entry` (implicit
+  access was deprecated and stopped working in HA 2025.11)
+- Hashrate history no longer loses the first sample during setup and no longer risks
+  a `KeyError` when an update runs while the entry is being unloaded
+- Service definitions no longer offer a `target:` selector; the services expect a
+  single `entity_id` field, and target selection passed an incompatible list
+- Test suite updated to match the actual sensor/binary sensor implementations
+  (previously referenced a non-existent `AxeOSSensor` class)
+
+### Changed
+- Minimum supported Home Assistant version is now 2024.11
+- Initial refresh uses `async_config_entry_first_refresh()`
+- `FlowResult` replaced with `ConfigFlowResult`, `EntityCategory` imported from
+  `homeassistant.const`, platform list uses the `Platform` enum
+- Added GitHub Actions workflow that runs the pytest suite on pushes and pull requests
+
 ## [1.0.9] - 2025-02-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A comprehensive Home Assistant custom integration for monitoring and controlling **BitAxe** and **NerdAxe** Bitcoin miners.
 
-![AxeOS HA Integration logo](https://raw.githubusercontent.com/fgrfn/AxeOS-HA-Integration/main/brand/logo.png)
+<img src="https://raw.githubusercontent.com/fgrfn/AxeOS-HA-Integration/main/brand/logo.png" alt="AxeOS HA Integration logo" width="512">
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ A comprehensive Home Assistant custom integration for monitoring and controlling
 
 ## 📦 Installation
 
+> **Requirement:** Home Assistant 2024.11 or newer.
+
 ### HACS (Recommended)
 
 1. Open **HACS** in your Home Assistant instance
@@ -322,13 +324,11 @@ refresh_interval: 0
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and changes.
 
-### Latest Version (1.0.8)
-- ✨ Full NerdAxe device support with 25+ additional sensors
-- ✨ Extended hashrate metrics (1m, 10m, 1h, 1d)
-- ✨ PID controller monitoring
-- ✨ Stratum pool details
-- ✨ Hardware diagnostics
-- 🔧 Improved nested data path support
+### Latest Version (1.11.0)
+- 🔧 Compatibility with current Home Assistant releases (options flow fix, coordinator config entry)
+- 🔧 Requires Home Assistant 2024.11 or newer
+- 🔧 Fixed hashrate history losing its first sample
+- 🔧 Fixed service definitions (removed incompatible target selector)
 
 ---
 

--- a/custom_components/axeos_ha_integration/__init__.py
+++ b/custom_components/axeos_ha_integration/__init__.py
@@ -1,8 +1,8 @@
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from datetime import timedelta
 import logging
@@ -16,7 +16,13 @@ def get_logger(level):
     logger.setLevel(getattr(logging, level.upper(), logging.INFO))
     return logger
 
-PLATFORMS = ["sensor", "button", "binary_sensor", "number", "switch"]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SWITCH,
+]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Called when a config entry is created or loaded."""
@@ -30,18 +36,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = async_get_clientsession(hass)
     api = AxeOSAPI(session, host)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {}
+    entry_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
 
     async def async_update_data():
-        # Now entry_data exists!
         system_info = await api.get_system_info()
         if system_info is None:
             raise UpdateFailed(f"Cannot fetch system info from {host}")
 
         hr = system_info.get("hashRate")
         if hr is not None:
-            entry_data = hass.data[DOMAIN][entry.entry_id]
             history = entry_data.get("hashrate_history", [])
             history.append(hr)
             if len(history) > 100:
@@ -55,27 +58,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
+        config_entry=entry,
         name=f"{DOMAIN}_{host}",
         update_method=async_update_data,
         update_interval=timedelta(seconds=scan_interval),
     )
 
-    # Initial update to check connectivity
-    try:
-        await coordinator.async_refresh()
-    except Exception as err:
-        raise ConfigEntryNotReady(f"Initial update failed: {err}") from err
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady(f"Initial update not successful: {host}")
+    # Initial update to check connectivity; raises ConfigEntryNotReady on failure
+    await coordinator.async_config_entry_first_refresh()
 
     # Store coordinator and API client in hass.data for platforms
-    hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
-        "api": api,
-        "host": host,
-        "name": name,
-    }
+    entry_data.update(
+        {
+            "coordinator": coordinator,
+            "api": api,
+            "host": host,
+            "name": name,
+        }
+    )
 
     # Register device in device registry
     device_registry = dr.async_get(hass)

--- a/custom_components/axeos_ha_integration/binary_sensor.py
+++ b/custom_components/axeos_ha_integration/binary_sensor.py
@@ -8,10 +8,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN
 

--- a/custom_components/axeos_ha_integration/config_flow.py
+++ b/custom_components/axeos_ha_integration/config_flow.py
@@ -7,8 +7,8 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant import exceptions
 
@@ -34,13 +34,14 @@ class AxeOSHaIntegrationConfigFlow(
     VERSION = 1
 
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return AxeOSOptionsFlowHandler(config_entry)
+        return AxeOSOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """First step: ask for host, optional name, and scan interval."""
         errors: dict[str, str] = {}
 
@@ -83,9 +84,6 @@ class AxeOSHaIntegrationConfigFlow(
 
 class AxeOSOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle option flow, e.g. scan_interval, logging."""
-
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""

--- a/custom_components/axeos_ha_integration/manifest.json
+++ b/custom_components/axeos_ha_integration/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/fgrfn/AxeOS-HA-Integration/issues",
   "requirements": [],
-  "version": "1.10.5"
+  "version": "1.11.0"
 }

--- a/custom_components/axeos_ha_integration/sensor.py
+++ b/custom_components/axeos_ha_integration/sensor.py
@@ -12,10 +12,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN
 

--- a/custom_components/axeos_ha_integration/services.yaml
+++ b/custom_components/axeos_ha_integration/services.yaml
@@ -3,10 +3,6 @@
 restart_miner:
   name: Restart Miner
   description: Restart the BitAxe miner
-  target:
-    entity:
-      integration: axeos_ha_integration
-      domain: sensor
   fields:
     entity_id:
       name: Entity
@@ -19,10 +15,6 @@ restart_miner:
 set_frequency:
   name: Set Frequency
   description: Set the mining frequency (MHz)
-  target:
-    entity:
-      integration: axeos_ha_integration
-      domain: sensor
   fields:
     entity_id:
       name: Entity
@@ -45,10 +37,6 @@ set_frequency:
 set_voltage:
   name: Set Voltage
   description: Set the core voltage (mV)
-  target:
-    entity:
-      integration: axeos_ha_integration
-      domain: sensor
   fields:
     entity_id:
       name: Entity
@@ -71,10 +59,6 @@ set_voltage:
 set_fanspeed:
   name: Set Fan Speed
   description: Set the fan speed (%)
-  target:
-    entity:
-      integration: axeos_ha_integration
-      domain: sensor
   fields:
     entity_id:
       name: Entity

--- a/hacs.json
+++ b/hacs.json
@@ -8,9 +8,9 @@
   ],
   "iot_class": "local_polling",
   "filename": "axeos_ha_integration",
-  "version": "1.10.5",
+  "version": "1.11.0",
   "documentation": "https://github.com/fgrfn/AxeOS-HA-Integration",
-  "homeassistant": "2022.3.0",
+  "homeassistant": "2024.11.0",
   "render_readme": true,
   "type": "integration",
   "codeowners": [

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 # Test Requirements
+# aiohttp is intentionally not listed: homeassistant pins an exact aiohttp
+# version, and any additional constraint here makes pip's resolver fail.
 homeassistant>=2024.11.0
-pytest>=9.1.1
+pytest>=8.0.0
 pytest-asyncio>=0.21.0
-pytest-cov>=7.1.0
-aiohttp>=3.14.1
+pytest-cov>=4.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 # Test Requirements
+homeassistant>=2024.11.0
 pytest>=9.1.1
 pytest-asyncio>=0.21.0
 pytest-cov>=7.1.0

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2,6 +2,9 @@
 import pytest
 from unittest.mock import MagicMock
 
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import EntityCategory
+
 from custom_components.axeos_ha_integration.binary_sensor import (
     BINARY_SENSOR_TYPES,
     AxeOSBinarySensor,
@@ -16,95 +19,99 @@ def mock_coordinator():
     coordinator.data = {
         "overheat_mode": 1,
         "isUsingFallbackStratum": False,
-        "autofanspeed": True,
-        "invertfanpolarity": 0,
-        "flipscreen": 1,
-        "invertscreen": False,
+        "shutdown": 0,
+        "stratum_keep": True,
+        "boardVersion": "204",
+        "version": "v2.1.8",
     }
     coordinator.last_update_success = True
     return coordinator
+
+
+def make_sensor(coordinator, key: str, entry_id: str = "test_entry") -> AxeOSBinarySensor:
+    """Create a binary sensor entity from its BINARY_SENSOR_TYPES definition."""
+    name, path, device_class, entity_category = BINARY_SENSOR_TYPES[key]
+    return AxeOSBinarySensor(
+        coordinator,
+        entry_id,
+        name,
+        f"{entry_id}_{key}",
+        path,
+        key,
+        device_class,
+        entity_category,
+    )
 
 
 def test_binary_sensor_types_definition():
     """Test that binary sensor types are properly defined."""
     assert "overheat_mode" in BINARY_SENSOR_TYPES
     assert "isUsingFallbackStratum" in BINARY_SENSOR_TYPES
-    assert "autofanspeed" in BINARY_SENSOR_TYPES
-    
+
     # Test binary sensor type structure
     overheat_sensor = BINARY_SENSOR_TYPES["overheat_mode"]
-    assert len(overheat_sensor) == 3
+    assert len(overheat_sensor) == 4
     assert overheat_sensor[0] == "Overheat Mode"
+    assert overheat_sensor[2] == BinarySensorDeviceClass.PROBLEM
 
 
 def test_get_value_true_values():
     """Test get_value function with various true values."""
-    assert get_value(True) is True
-    assert get_value(1) is True
-    assert get_value("1") is True
-    assert get_value("true") is True
-    assert get_value("True") is True
-    assert get_value("TRUE") is True
-    assert get_value("on") is True
-    assert get_value("On") is True
-    assert get_value("yes") is True
+    assert get_value({"k": True}, ["k"]) is True
+    assert get_value({"k": 1}, ["k"]) is True
+    assert get_value({"k": "1"}, ["k"]) is True
+    assert get_value({"k": "true"}, ["k"]) is True
+    assert get_value({"k": "True"}, ["k"]) is True
+    assert get_value({"k": "TRUE"}, ["k"]) is True
+    assert get_value({"k": "on"}, ["k"]) is True
+    assert get_value({"k": "On"}, ["k"]) is True
+    assert get_value({"k": "yes"}, ["k"]) is True
 
 
 def test_get_value_false_values():
     """Test get_value function with various false values."""
-    assert get_value(False) is False
-    assert get_value(0) is False
-    assert get_value("0") is False
-    assert get_value("false") is False
-    assert get_value("False") is False
-    assert get_value("off") is False
-    assert get_value("no") is False
-    assert get_value(None) is False
+    assert get_value({"k": False}, ["k"]) is False
+    assert get_value({"k": 0}, ["k"]) is False
+    assert get_value({"k": "0"}, ["k"]) is False
+    assert get_value({"k": "false"}, ["k"]) is False
+    assert get_value({"k": "False"}, ["k"]) is False
+    assert get_value({"k": "off"}, ["k"]) is False
+    assert get_value({"k": "no"}, ["k"]) is False
+
+
+def test_get_value_missing_key():
+    """Test get_value function with a missing key."""
+    assert get_value({}, ["missing"]) is None
+
+
+def test_get_value_nested_path():
+    """Test get_value function with a nested dotted path."""
+    data = {"stratum": {"usingFallback": True}}
+    assert get_value(data, ["stratum.usingFallback"]) is True
 
 
 def test_binary_sensor_is_on(mock_coordinator):
     """Test binary sensor is_on property."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "overheat_mode",
-        "Overheat Mode",
-        "overheat_mode",
-        "mdi:fire",
-    )
-    
+    sensor = make_sensor(mock_coordinator, "overheat_mode")
+
     # overheat_mode is 1, should be True
     assert sensor.is_on is True
 
 
 def test_binary_sensor_is_on_boolean(mock_coordinator):
     """Test binary sensor with boolean value."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "isUsingFallbackStratum",
-        "Fallback Stratum",
-        "isUsingFallbackStratum",
-        "mdi:server-network",
-    )
-    
+    sensor = make_sensor(mock_coordinator, "isUsingFallbackStratum")
+
     # isUsingFallbackStratum is False
     assert sensor.is_on is False
 
 
 def test_binary_sensor_availability(mock_coordinator):
     """Test binary sensor availability."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "autofanspeed",
-        "Auto Fan Speed",
-        "autofanspeed",
-        "mdi:fan-auto",
-    )
-    
+    sensor = make_sensor(mock_coordinator, "overheat_mode")
+
     assert sensor.available is True
-    
+
     # Test unavailable when coordinator fails
     mock_coordinator.last_update_success = False
     assert sensor.available is False
@@ -112,43 +119,23 @@ def test_binary_sensor_availability(mock_coordinator):
 
 def test_binary_sensor_missing_data(mock_coordinator):
     """Test binary sensor when data is missing."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "missing_key",
-        "Missing",
-        "nonexistent_key",
-        "mdi:help",
-    )
-    
-    assert sensor.is_on is False
+    sensor = make_sensor(mock_coordinator, "otp")
+
+    assert sensor.is_on is None
+    assert sensor.available is False
 
 
 def test_binary_sensor_unique_id(mock_coordinator):
     """Test binary sensor unique ID generation."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry_123",
-        "overheat_mode",
-        "Overheat Mode",
-        "overheat_mode",
-        "mdi:fire",
-    )
-    
+    sensor = make_sensor(mock_coordinator, "overheat_mode", entry_id="test_entry_123")
+
     assert sensor.unique_id == "test_entry_123_overheat_mode"
 
 
 def test_binary_sensor_device_info(mock_coordinator):
     """Test binary sensor device info."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry_123",
-        "overheat_mode",
-        "Overheat Mode",
-        "overheat_mode",
-        "mdi:fire",
-    )
-    
+    sensor = make_sensor(mock_coordinator, "overheat_mode", entry_id="test_entry_123")
+
     device_info = sensor.device_info
     assert device_info is not None
     assert ("axeos_ha_integration", "test_entry_123") in device_info["identifiers"]
@@ -156,27 +143,13 @@ def test_binary_sensor_device_info(mock_coordinator):
 
 def test_binary_sensor_entity_category(mock_coordinator):
     """Test binary sensor entity category."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "overheat_mode",
-        "Overheat Mode",
-        "overheat_mode",
-        "mdi:fire",
-    )
-    
-    assert sensor.entity_category == "diagnostic"
+    sensor = make_sensor(mock_coordinator, "overheat_mode")
+
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
 
 
-def test_binary_sensor_icon(mock_coordinator):
-    """Test binary sensor icon."""
-    sensor = AxeOSBinarySensor(
-        mock_coordinator,
-        "test_entry",
-        "autofanspeed",
-        "Auto Fan Speed",
-        "autofanspeed",
-        "mdi:fan-auto",
-    )
-    
-    assert sensor.icon == "mdi:fan-auto"
+def test_binary_sensor_device_class(mock_coordinator):
+    """Test binary sensor device class."""
+    sensor = make_sensor(mock_coordinator, "overheat_mode")
+
+    assert sensor.device_class == BinarySensorDeviceClass.PROBLEM

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,14 @@
 """Tests for the AxeOS HA Integration sensor platform."""
 import pytest
-from unittest.mock import MagicMock
-from homeassistant.const import UnitOfPower, UnitOfElectricPotential, UnitOfElectricCurrent
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import EntityCategory
 
 from custom_components.axeos_ha_integration.sensor import (
     SENSOR_TYPES,
-    AxeOSSensor,
+    AxeOSHASensor,
+    get_value,
 )
 
 
@@ -25,9 +28,34 @@ def mock_coordinator():
         "frequency": 485,
         "coreVoltage": 1250,
         "fanspeed": 75,
+        "boardVersion": "204",
+        "version": "v2.1.8",
     }
     coordinator.last_update_success = True
     return coordinator
+
+
+def make_sensor(coordinator, key: str, entry_id: str = "test_entry") -> AxeOSHASensor:
+    """Create a sensor entity from its SENSOR_TYPES definition."""
+    name, unit, path, device_class, state_class, entity_category = SENSOR_TYPES[key]
+    return AxeOSHASensor(
+        coordinator,
+        entry_id,
+        name,
+        f"{entry_id}_{key}",
+        unit,
+        path,
+        key,
+        device_class,
+        state_class,
+        entity_category,
+    )
+
+
+def refresh(sensor: AxeOSHASensor) -> None:
+    """Trigger a coordinator update without a hass instance."""
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._handle_coordinator_update()
 
 
 def test_sensor_types_definition():
@@ -36,125 +64,86 @@ def test_sensor_types_definition():
     assert "voltage" in SENSOR_TYPES
     assert "temp" in SENSOR_TYPES
     assert "hashRate" in SENSOR_TYPES
-    
+
     # Test sensor type structure
     power_sensor = SENSOR_TYPES["power"]
-    assert len(power_sensor) == 7  # 7 elements in tuple
-    assert power_sensor[0] == "Power"
-    assert power_sensor[1] == UnitOfPower.WATT
+    assert len(power_sensor) == 6  # 6 elements in tuple
+    assert power_sensor[0] == "Power Consumption"
+    assert power_sensor[1] == "W"
+    assert power_sensor[2] == ["power"]
+    assert power_sensor[3] == SensorDeviceClass.POWER
+    assert power_sensor[4] == SensorStateClass.MEASUREMENT
+
+
+def test_get_value_flat_key():
+    """Test get_value with a plain key."""
+    assert get_value({"power": 12.5}, ["power"]) == 12.5
+
+
+def test_get_value_alternative_keys():
+    """Test get_value trying alternative keys."""
+    assert get_value({"hostip": "1.2.3.4"}, ["ip", "hostip"]) == "1.2.3.4"
+
+
+def test_get_value_nested_path():
+    """Test get_value following a nested path."""
+    data = {"stratum": {"poolMode": "solo"}}
+    assert get_value(data, ["stratum", "poolMode"]) == "solo"
+
+
+def test_get_value_missing():
+    """Test get_value with a missing key."""
+    assert get_value({"power": 12.5}, ["nonexistent"]) is None
+    assert get_value({}, []) is None
 
 
 def test_sensor_native_value(mock_coordinator):
-    """Test sensor native value property."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "power",
-        "Power",
-        UnitOfPower.WATT,
-        "power",
-        "power",
-        "measurement",
-        None,
-        2,
-    )
-    
+    """Test sensor native value after a coordinator update."""
+    sensor = make_sensor(mock_coordinator, "power")
+    refresh(sensor)
+
     assert sensor.native_value == 12.5
 
 
 def test_sensor_availability(mock_coordinator):
     """Test sensor availability."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "power",
-        "Power",
-        UnitOfPower.WATT,
-        "power",
-        "power",
-        "measurement",
-        None,
-        2,
-    )
-    
+    sensor = make_sensor(mock_coordinator, "power")
+    refresh(sensor)
+
     assert sensor.available is True
-    
+
     # Test unavailable when coordinator fails
     mock_coordinator.last_update_success = False
     assert sensor.available is False
 
 
-def test_sensor_nested_data_path(mock_coordinator):
-    """Test sensor with nested data path."""
-    mock_coordinator.data["wifi"] = {"status": "Connected"}
-    
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "wifi_status",
-        "WiFi Status",
-        None,
-        "wifi.status",
-        None,
-        None,
-        None,
-        None,
-    )
-    
-    assert sensor.native_value == "Connected"
-
-
 def test_sensor_missing_data(mock_coordinator):
     """Test sensor when data is missing."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "missing_key",
-        "Missing",
-        None,
-        "nonexistent_key",
-        None,
-        None,
-        None,
-        None,
-    )
-    
+    sensor = make_sensor(mock_coordinator, "ssid")
+    refresh(sensor)
+
     assert sensor.native_value is None
+    assert sensor.available is False
 
 
 def test_sensor_unique_id(mock_coordinator):
     """Test sensor unique ID generation."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry_123",
-        "power",
-        "Power",
-        UnitOfPower.WATT,
-        "power",
-        "power",
-        "measurement",
-        None,
-        2,
-    )
-    
+    sensor = make_sensor(mock_coordinator, "power", entry_id="test_entry_123")
+
     assert sensor.unique_id == "test_entry_123_power"
+
+
+def test_sensor_unit(mock_coordinator):
+    """Test sensor unit of measurement."""
+    sensor = make_sensor(mock_coordinator, "power")
+
+    assert sensor.native_unit_of_measurement == "W"
 
 
 def test_sensor_device_info(mock_coordinator):
     """Test sensor device info."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry_123",
-        "power",
-        "Power",
-        UnitOfPower.WATT,
-        "power",
-        "power",
-        "measurement",
-        None,
-        2,
-    )
-    
+    sensor = make_sensor(mock_coordinator, "power", entry_id="test_entry_123")
+
     device_info = sensor.device_info
     assert device_info is not None
     assert ("axeos_ha_integration", "test_entry_123") in device_info["identifiers"]
@@ -162,36 +151,32 @@ def test_sensor_device_info(mock_coordinator):
 
 def test_sensor_display_precision(mock_coordinator):
     """Test sensor display precision."""
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "power",
-        "Power",
-        UnitOfPower.WATT,
-        "power",
-        "power",
-        "measurement",
-        None,
-        2,  # 2 decimal places
-    )
-    
+    sensor = make_sensor(mock_coordinator, "power")
+
     assert sensor.suggested_display_precision == 2
+
+    hashrate_sensor = make_sensor(mock_coordinator, "hashRate")
+    assert hashrate_sensor.suggested_display_precision == 0
 
 
 def test_sensor_entity_category(mock_coordinator):
     """Test sensor entity category."""
-    # Test diagnostic sensor
-    sensor = AxeOSSensor(
-        mock_coordinator,
-        "test_entry",
-        "uptimeSeconds",
-        "Uptime",
-        "s",
-        "uptimeSeconds",
-        None,
-        None,
-        "diagnostic",
-        None,
-    )
-    
-    assert sensor.entity_category == "diagnostic"
+    # uptimeSeconds is a diagnostic sensor
+    sensor = make_sensor(mock_coordinator, "uptimeSeconds")
+
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+
+    # power is a regular sensor
+    power_sensor = make_sensor(mock_coordinator, "power")
+    assert power_sensor.entity_category is None
+
+
+def test_sensor_hashrate_history_attributes(mock_coordinator):
+    """Test hashrate history attributes on the hashRate sensor."""
+    mock_coordinator.data["hashrate_history"] = [400.0, 500.0, 600.0]
+    sensor = make_sensor(mock_coordinator, "hashRate")
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["hashrate_min"] == 400.0
+    assert attrs["hashrate_max"] == 600.0
+    assert attrs["hashrate_avg"] == 500.0


### PR DESCRIPTION
## Summary

Review of the integration against current Home Assistant releases found two breaking deprecations and several smaller issues. This PR fixes them and bumps the version to **1.11.0**.

### Breaking on current Home Assistant (fixed)

- **Options flow crashed on HA 2025.12+**: `AxeOSOptionsFlowHandler` explicitly assigned `self.config_entry`, which was deprecated in HA 2024.11 and removed in HA 2025.12. Opening the "Configure" dialog failed on up-to-date installs. The handler now relies on the `config_entry` property provided by the base class.
- **`DataUpdateCoordinator` without explicit `config_entry`**: implicit config entry access was deprecated and stopped working in HA 2025.11. The coordinator is now created with `config_entry=entry`, and the initial refresh uses `async_config_entry_first_refresh()`.

### Other fixes

- Hashrate history: the `hass.data` dict was replaced after the first refresh, discarding the first history sample; the update callback could also `KeyError` if it ran during unload. The entry dict is now created once and updated in place.
- `services.yaml` offered a `target:` selector, but the service handlers only accept a single `entity_id` field — selecting a target in the UI passed a list and failed schema validation. The target blocks are removed; the explicit entity field remains.
- **Tests were broken and never ran in CI**: `tests/test_sensor.py` imported a non-existent `AxeOSSensor` class and `tests/test_binary_sensor.py` used outdated signatures. Both are rewritten to match the actual implementation (35 tests, all passing), `homeassistant` was added to `requirements-test.txt`, and a new `test.yml` workflow runs pytest on pushes and PRs.

### Modernization

- `FlowResult` → `ConfigFlowResult`, `EntityCategory` imported from `homeassistant.const`, platform list uses the `Platform` enum.
- Minimum HA version in `hacs.json` raised from 2022.3.0 to **2024.11.0** (required by the options flow fix); noted in README.
- README/CHANGELOG updated (stale "Latest Version (1.0.8)" section).

### Versioning

`manifest.json` and `hacs.json` both bumped to 1.11.0 (kept in sync for the version-sync workflow; minor bump because the minimum HA version changes).

## Test plan

- [x] `pytest tests/` — 35 passed locally
- [x] All integration modules import cleanly
- [ ] CI workflows green (including the new Tests workflow)
- [ ] Smoke test on a live HA 2025.12+ install: add miner, open options dialog, change scan interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df2aQvcZsu1EsHBs4n7pDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df2aQvcZsu1EsHBs4n7pDt)_